### PR TITLE
chore: update CircleCI configuration for making releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,22 +111,51 @@ jobs:
   make-release:
     executor: rust-env
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - $SSH_FINGERPRINT
       - checkout
+      - run:
+          name: import GPG key
+          command: |
+            echo -e $GPG2 | gpg --batch --no-tty --import --yes
       - run:
           name: Configure git for user and signing
           command: |
-            git config --global user.email "$USER_EMAIL"
-            git config --global user.name "$USER_NAME"
-            git config --global gpg.format ssh
-            git config --global user.signingKey "$SSH_PUB"
-            git config --local --list
+            git config user.email "$USER_EMAIL"
+            git config user.name "$USER_NAME"
+            git config --global gpg.program gpg
+            git config --global user.signingkey "$SSH_PUB"
       - run:
           name: Publish update
           command: |
-            cargo release -vv --registry spare --execute --no-confirm "$(nextsv -q -e feature -r 'CHANGES.md' -r 'CHANGELOG.md')"
+            set -exo pipefail
+            export NEXTSV_LEVEL=$(nextsv -q -c other require -f CHANGES.md -f CHANGELOG.md feature)
+            if [ $NEXTSV_LEVEL != "none" ] ; then 
+              cargo release changes
+              cargo release -vvv --execute --no-confirm --sign-tag "$NEXTSV_LEVEL"
+            else 
+              echo "Not ready to release yet."
+            fi
+
+  # make-release:
+  #   executor: rust-env
+  #   steps:
+  #     - add_ssh_keys:
+  #         fingerprints:
+  #           - $SSH_FINGERPRINT
+  #     - checkout
+  #     - run:
+  #         name: Configure git for user and signing
+  #         command: |
+  #           git config --global user.email "$USER_EMAIL"
+  #           git config --global user.name "$USER_NAME"
+  #           git config --global gpg.format ssh
+  #           git config --global user.signingKey "$SSH_PUB"
+  #           git config --local --list
+  #     - run:
+  #         name: Publish update
+  #         command: |
+  #           cargo release -vv --registry spare --execute --no-confirm "$(nextsv -q -e feature -r 'CHANGES.md' -r 'CHANGELOG.md')"
+
+
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -34,7 +34,7 @@ jobs:
           results_format: sarif
           # Read-only PAT token. To create it,
           # follow the steps in https://github.com/ossf/scorecard-action#pat-token-creation.
-          repo_token: ${{ secrets.SCORECARD_READ_TOKEN }}
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
           # Publish the results to enable scorecard badges. For more details, see
           # https://github.com/ossf/scorecard-action#publishing-results.
           # For private repositories, `publish_results` will automatically be set to `false`,


### PR DESCRIPTION
This commit updates the CircleCI configuration file to make releases. It adds the necessary steps to import the GPG key, configure git for user and signing, and publish updates. The release process is now triggered when the feature level in the CHANGES.md and CHANGELOG.md files is not "none". If the feature level is "none", the release is skipped.