### PR TITLE
Update-changelog-file-references-in-release-config

### DIFF
--- a/PRLOG.md
+++ b/PRLOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 🔥 chore(changelog)-remove CHANGELOG.md file(pr [#766])
 - 👷 ci(config)-update pipeline flags and conditions(pr [#767])
+- Update-changelog-file-references-in-release-config(pr [#768])
 
 ### Fixed
 
@@ -865,6 +866,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#763]: https://github.com/jerus-org/mockd/pull/763
 [#766]: https://github.com/jerus-org/mockd/pull/766
 [#767]: https://github.com/jerus-org/mockd/pull/767
+[#768]: https://github.com/jerus-org/mockd/pull/768
 [Unreleased]: https://github.com/jerus-org/mockd/compare/v0.4.52...HEAD
 [0.4.52]: https://github.com/jerus-org/mockd/compare/v0.4.51...v0.4.52
 [0.4.51]: https://github.com/jerus-org/mockd/compare/v0.4.50...v0.4.51

--- a/release-hook.sh
+++ b/release-hook.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Build Changelog
+gen-changelog generate --display-summaries --next-version "$SEMVER"

--- a/release.toml
+++ b/release.toml
@@ -8,7 +8,7 @@ allow-branch = ["main"]
 pre-release-replacements = [
     { file = "README.md", search = "mockd = .*", replace = "{{crate_name}} = \"{{version}}\"" },
     { file = "src/lib.rs", search = "mockd = .*", replace = "{{crate_name}} = \"{{version}}\"" },
-    { file = "CHANGELOG.md", search = "## \\[Unreleased\\]", replace = "## [{{version}}] - {{date}}", exactly = 1 },
-    { file = "CHANGELOG.md", search = "\\[Unreleased\\]:", replace = "[{{version}}]:", exactly = 1 },
-    { file = "CHANGELOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", exactly = 1 },
+    { file = "PRLOG.md", search = "## \\[Unreleased\\]", replace = "## [{{version}}] - {{date}}", exactly = 1 },
+    { file = "PRLOG.md", search = "\\[Unreleased\\]:", replace = "[{{version}}]:", exactly = 1 },
+    { file = "PRLOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", exactly = 1 },
 ]


### PR DESCRIPTION
- introduce new release-hook.sh script
- utilize gen-changelog for building changelog with versioning support